### PR TITLE
Fix support for CF_HOME, add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dbellotti/cf-target
+
+go 1.19

--- a/main.go
+++ b/main.go
@@ -29,8 +29,9 @@ func main() {
 
 	cfHome := os.Getenv("CF_HOME")
 	if cfHome == "" {
-		cfHome = filepath.Join(os.Getenv("HOME"), ".cf")
+		cfHome = os.Getenv("HOME")
 	}
+	cfHome = filepath.Join(cfHome, ".cf")
 
 	f, err := os.Open(filepath.Join(cfHome, "config.json"))
 	if err != nil {


### PR DESCRIPTION
The cf-cli appends `.cf` to both `$HOME` and `$CF_HOME`, so updating this to do the same.